### PR TITLE
Update vhs.yml

### DIFF
--- a/.github/workflows/vhs.yml
+++ b/.github/workflows/vhs.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [19]
-        pnpm-version: [8]
+        node-version: [20]
+        pnpm-version: [9]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

_Concise description of proposed changes_

## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:

## Summary by Sourcery

Build:
- Bump Node.js version from 19 to 20 and pnpm from 8 to 9 in the vhs CI workflow matrix.