### PR TITLE
Revert "Master"

### DIFF
--- a/.changeset/green-buses-battle.md
+++ b/.changeset/green-buses-battle.md
@@ -1,5 +1,0 @@
----
-"@wagmi/cli": patch
----
-
-feat: Soften duplicate contract name in the case contracts have identical ABIs

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Update package versions
         run: pnpm version:update
       
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+      - uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Reverts Dargon789/wagmi#266

## Summary by Sourcery

Revert the previous automated changes by restoring the earlier git-auto-commit GitHub Action version and removing the associated changeset entry.

CI:
- Revert git-auto-commit GitHub Action in the verify workflow to the earlier v6.0.1 version.

Chores:
- Remove the changeset file introduced by the reverted change.